### PR TITLE
Remove '+' from Safe character list

### DIFF
--- a/furl/furl.py
+++ b/furl/furl.py
@@ -301,8 +301,8 @@ class Query(object):
       encoded query strings are provided to methods that take such strings, like
       load(), add(), set(), remove(), etc.
   """
-  SAFE_KEY_CHARS   = "/?:@-._~!$'()*+,"
-  SAFE_VALUE_CHARS = "/?:@-._~!$'()*+,="
+  SAFE_KEY_CHARS   = "/?:@-._~!$'()*,"
+  SAFE_VALUE_CHARS = "/?:@-._~!$'()*,="
   
   def __init__(self, query='', strict=False):
     self.strict = strict


### PR DESCRIPTION
Though '+' is a legal character per RFC1738, it's interpreted as a space
in modern usage. 

This has the effect of corrupting values such as `rhettg+github@gmail.com` as `rhettg github@gmail.com` by applications which use `urllib.unquote_plus` (and probably many others).

I don't know where this standard is defined. Interestingly, the wikipedia entry on it is noted as needing a citation: http://en.wikipedia.org/wiki/Query_string
