### PR TITLE
comparison_enchancements: Allow comparison of Path objects with other Path objects and strings. Also fixes a bug that would raise an error when comparing a furl instance with a string.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-.py[co]
+*.py[co]
 .coverage
 .cover

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.py[co]
+.coverage
+.cover

--- a/furl/furl.py
+++ b/furl/furl.py
@@ -177,6 +177,14 @@ class Path(object):
   def __repr__(self):
     return "%s('%s')" % (self.__class__.__name__, str(self))
 
+  def __eq__(self, other):
+    try:
+      is_equal = str(self) == str(other)
+    except (TypeError, ValueError):
+      is_equal = False
+
+    return is_equal
+
   def _segments_from_path(self, path):
     """
     Returns: The list of path segments from the path string <path>.

--- a/furl/furl.py
+++ b/furl/furl.py
@@ -1054,7 +1054,7 @@ class furl(URLPathCompositionInterface, QueryCompositionInterface,
     return self.__class__(self)
 
   def __eq__(self, other):
-    return self.url == other.url
+    return self.url == str(other)
 
   def __setattr__(self, attr, value):
     if (not PathCompositionInterface.__setattr__(self, attr, value) and

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -1410,7 +1410,7 @@ class TestFurl(unittest.TestCase):
     assert furl.furl() is not furl.furl() and furl.furl() == furl.furl()
 
     url = 'https://www.yahoo.co.uk/one/two/three?a=a&b=b&m=m%26m#fragment'
-    assert furl.furl(url) == furl.furl(url)
+    assert furl.furl(url) == furl.furl(url) == url
     assert furl.furl(url).remove(path=True) != furl.furl(url)
 
   def test_urlsplit(self):

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -420,6 +420,19 @@ class TestPath(unittest.TestCase):
     p = furl.Path('/asdf')
     assert p
 
+  def test_equality_comparison(self):
+    a = furl.Path('asdf')
+    b = furl.Path('asdf')
+    assert a == b
+
+    c = furl.Path('asdf/a')
+    c.remove('/a')
+    assert a == b == c
+
+    d = furl.Path('/some/long/path/possibly/')
+    e = furl.Path('/some/long/path/possibly/')
+    assert d == e
+
 
 class TestQuery(unittest.TestCase):
   def setUp(self):


### PR DESCRIPTION
# Description:

Pretty much in the title.
This pull request does two things:
1. Allows comparison of Path objects with other Path objects and strings.
2. Fixes a bug when comparing equality of a furl instance to a string, which would previously raise an error.
In addition to adding a simple .gitignore file for Python.



### By the way

BTW, very nice library. Was looking for something similar, didn't find it previously so I ended up making a very simple version of this to use for work purposes. Found this recently and it does the trick for the most part. If you are open to pull requests, I'd like to add a bit of "magic" to this to make furl itself be the replacement of a string, so that one does not need to always cast furl to a string to do things such as redirect, resolve, etc. within Django and the like.