### PR TITLE
setup.py: Don't pin exact version of six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'six==1.8.0',
+        'six>=1.8.0',
         'orderedmultidict>=0.7.4',
     ],
     test_suite='tests',


### PR DESCRIPTION
Since furl is a library, having furl pin exact versions of dependencies means you are limiting the usability of furl when you pin an exact version of `six`. Six months down the road, someone may have an app and want to use `six>=1.9.0` or even `six==1.8.2` (Or a library the app uses may require this) and then they'll be stuck. Best to keep dependencies as loose as possible. If furl works with `six==1.6.0` for example then change it to require `six>=1.6` and more people will be able to use furl.
