### PR TITLE
Add test for unicode keys and values

### DIFF
--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -1901,6 +1901,6 @@ class TestFurl(unittest.TestCase):
 
     def test_unicode_query_keys_and_values(self):
         f = furl.furl('http://site4dads.ru/')
-        f.args[u'testö'] = u'testä'
+        f.args[six.u('testö')] = six.u('testä')
 
         assert f.url == 'http://site4dads.ru/?test%C3%B6=test%C3%A4'

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -1898,3 +1898,9 @@ class TestFurl(unittest.TestCase):
             assert furl.is_valid_encoded_query_value(valid)
         for invalid in invalids:
             assert not furl.is_valid_encoded_query_value(invalid)
+
+    def test_unicode_query_keys_and_values(self):
+        f = furl.furl('http://site4dads.ru/')
+        f.args[u'testö'] = u'testä'
+
+        assert f.url == 'http://site4dads.ru/?test%C3%B6=test%C3%A4'

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -1903,4 +1903,4 @@ class TestFurl(unittest.TestCase):
         f = furl.furl('http://site4dads.ru/')
         f.args[six.u('testö')] = six.u('testä')
 
-        assert f.url == 'http://site4dads.ru/?test%C3%B6=test%C3%A4'
+        self.assertEqual(f.url, 'http://site4dads.ru/?test%C3%B6=test%C3%A4')


### PR DESCRIPTION
This implements the test from the comments of
https://github.com/gruns/furl/issues/32 and demonstrates a regression
(bug was reported in 0.3.mumble, fixed in 0.3.8, and is now broken in
0.4.1 and 0.4.2)