### PR TITLE
Spell 'delimiter' correctly, both in API and documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -282,7 +282,7 @@ parameter value.
 'http://sprop.su/?param'
 ```
 
-__encode(delimiter='&')__ can be used to encode query strings with delimeters
+__encode(delimiter='&')__ can be used to encode query strings with delimiters
 like `;`.
 
 ```python

--- a/furl/furl.py
+++ b/furl/furl.py
@@ -518,17 +518,25 @@ class Query(object):
         for key, value in items:
             self._params.add(key, value)
 
-    def encode(self, delimeter='&'):
+    def encode(self, delimiter='&', delimeter=None):
         """
         Examples:
           Query('a=a&b=#').encode() == 'a=a&b=%23'
           Query('a=a&b=#').encode(';') == 'a=a;b=%23'
 
-        Returns: A URL encoded query string using <delimeter> as the
-        delimeter separating key:value pairs. The most common and
-        default delimeter is '&', but ';' can also be specified. ';' is
+        Returns: A URL encoded query string using <delimiter> as the
+        delimiter separating key:value pairs. The most common and
+        default delimiter is '&', but ';' can also be specified. ';' is
         W3C recommended.
         """
+
+        if delimeter is not None:
+            # Backwards compatibility: for a long time, the 'delimiter'
+            # arg was spelled incorrectly as 'delimeter'. Existing code
+            # using a keyword arg with the wrong spelling should keep
+            # working.
+            delimiter = delimeter
+
         pairs = []
         for key, value in self.params.iterallitems():
             utf8key = utf8(key, utf8(attemptstr(key)))
@@ -539,7 +547,7 @@ class Query(object):
             if value is None:  # Example: http://sprop.su/?param
                 pair = quoted_key
             pairs.append(pair)
-        return delimeter.join(pairs)
+        return delimiter.join(pairs)
 
     def __eq__(self, other):
         return str(self) == str(other)

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -548,7 +548,7 @@ class TestQuery(unittest.TestCase):
             'a=a&a=a', 'space=a+a&space=b+b',
             # Empty keys and/or values.
             '=', 'a=', 'a=a&a=', '=a&=b',
-            # Semicolon delimeter, like 'a=a;b=b'.
+            # Semicolon delimiter, like 'a=a;b=b'.
             'a=a;a=a', 'space=a+a;space=b+b',
         ]))
         self.items = (self.itemlists + self.itemdicts + self.itemomdicts +
@@ -675,7 +675,7 @@ class TestQuery(unittest.TestCase):
         q = furl.Query('a=&=b')
         assert q.params == {'a': '', '': 'b'} and str(q) == 'a=&=b'
 
-        # ';' is a valid query delimeter.
+        # ';' is a valid query delimiter.
         q = furl.Query('=;=')
         assert q.params.allitems() == [('', ''), ('', '')] and str(q) == '=&='
         q = furl.Query('a=a;b=b;c=')
@@ -1287,7 +1287,7 @@ class TestFurl(unittest.TestCase):
         assert str(f.fragment) == ''
         assert f.url == ''
 
-        # Keep in mind that ';' is a query delimeter for both the URL
+        # Keep in mind that ';' is a query delimiter for both the URL
         # query and the fragment query, resulting in the str(path),
         # str(query), and str(fragment) values below.
         url = (
@@ -1676,7 +1676,7 @@ class TestFurl(unittest.TestCase):
         assert furl.furl(url).remove(path=True) != furl.furl(url)
 
     def test_urlsplit(self):
-        # Without any delimeters like '://' or '/', the input should be
+        # Without any delimiters like '://' or '/', the input should be
         # treated as a path.
         urls = ['sup', '127.0.0.1', 'www.google.com', '192.168.1.1:8000']
         for url in urls:


### PR DESCRIPTION
...but don't break existing code by adding a small compatibility check
for existing code using a keyword arg with the wrong spelling.

Fixes #50.