### PR TITLE
Fix failing furl(unicode_object) on python 2.

### DIFF
--- a/furl/furl.py
+++ b/furl/furl.py
@@ -878,7 +878,7 @@ class furl(URLPathCompositionInterface, QueryCompositionInterface,
         self._host = self._port = self._scheme = None
         self.username = self.password = self.scheme = None
 
-        if not isinstance(url, str):
+        if not isinstance(url, six.string_types):
             url = str(url)
 
         # urlsplit() raises a ValueError on malformed IPv6 addresses in

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -1001,13 +1001,18 @@ class TestFurl(unittest.TestCase):
         key_encoded, value_encoded = u'test%C3%B6', u'test%C3%A4'
 
         base_url = 'http://pumps.ru'
-        full_url = '%s/%s?%s=%s' % (
+        full_url_utf8_encoded_str = '%s/%s?%s=%s' % (
             base_url, paths[0], pairs[0][0], pairs[0][1])
+        full_url_unicode = u'%s/%s?%s=%s' % (
+            base_url, paths[1], pairs[1][0], pairs[1][1])
         full_url_encoded = '%s/%s?%s=%s' % (
             base_url, path_encoded, key_encoded, value_encoded)
 
+        f = furl.furl(full_url_utf8_encoded_str)
+        assert f.url == full_url_encoded
+
         # Accept unicode without raising an exception.
-        f = furl.furl(full_url)
+        f = furl.furl(full_url_unicode)
         assert f.url == full_url_encoded
 
         # Accept unicode paths.

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -1918,3 +1918,10 @@ class TestFurl(unittest.TestCase):
             assert furl.is_valid_encoded_query_value(valid)
         for invalid in invalids:
             assert not furl.is_valid_encoded_query_value(invalid)
+
+    def test_py2_unicode_regression_issue_52(self):
+        """
+        Test that `furl.furl()` handles python 2 `unicode` objects without
+        raising `UnicodeEncodeError`.
+        """
+        assert furl.furl(u'ę').url == '%C4%99'


### PR DESCRIPTION
Tests that an actual non utf-8 encoded `unicode` string can be passed to `furl.furl()` and attempts to fix the resulting `UnicodeEncodeError`.