### PR TITLE
Add options for encoding URL parameters

### DIFF
--- a/furl/furl.py
+++ b/furl/furl.py
@@ -448,8 +448,9 @@ class Query(object):
     SAFE_KEY_CHARS = "/?:@-._~!$'()*,"
     SAFE_VALUE_CHARS = "/?:@-._~!$'()*,="
 
-    def __init__(self, query='', strict=False):
+    def __init__(self, query='', strict=False, use_quote_plus=True):
         self.strict = strict
+        self.use_quote_plus = use_quote_plus
 
         self._params = omdict1D()
 
@@ -507,6 +508,13 @@ class Query(object):
         return self
 
     @property
+    def quote_method(self):
+        if self.use_quote_plus:
+            return quote_plus
+        else:
+            return quote
+
+    @property
     def params(self):
         return self._params
 
@@ -540,8 +548,8 @@ class Query(object):
         for key, value in self.params.iterallitems():
             utf8key = utf8(key, utf8(attemptstr(key)))
             utf8value = utf8(value, utf8(attemptstr(value)))
-            quoted_key = quote_plus(utf8key, self.SAFE_KEY_CHARS)
-            quoted_value = quote_plus(utf8value, self.SAFE_VALUE_CHARS)
+            quoted_key = self.quote_method(utf8key, self.SAFE_KEY_CHARS)
+            quoted_value = self.quote_method(utf8value, self.SAFE_VALUE_CHARS)
             pair = '='.join([quoted_key, quoted_value])
             if value is None:  # Example: http://sprop.su/?param
                 pair = quoted_key
@@ -644,8 +652,8 @@ class QueryCompositionInterface(object):
     Abstract class interface for a parent class that contains a Query.
     """
 
-    def __init__(self, strict=False):
-        self._query = Query(strict=strict)
+    def __init__(self, strict=False, use_quote_plus=True):
+        self._query = Query(strict=strict, use_quote_plus=use_quote_plus)
 
     @property
     def query(self):
@@ -857,12 +865,12 @@ class furl(URLPathCompositionInterface, QueryCompositionInterface,
       fragment: Fragment object from FragmentCompositionInterface.
     """
 
-    def __init__(self, url='', strict=False):
+    def __init__(self, url='', strict=False, use_quote_plus=True):
         """
         Raises: ValueError on invalid url.
         """
         URLPathCompositionInterface.__init__(self, strict=strict)
-        QueryCompositionInterface.__init__(self, strict=strict)
+        QueryCompositionInterface.__init__(self, strict=strict, use_quote_plus=use_quote_plus)
         FragmentCompositionInterface.__init__(self, strict=strict)
         self.strict = strict
 

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -702,6 +702,10 @@ class TestQuery(unittest.TestCase):
         q.params['p+p'] = 'p+p'
         assert str(q) == 's+s=s+s&p%2Bp=p%2Bp'
 
+        # Quote Plus to set False
+        q = furl.Query('s s=s s', use_quote_plus=False)
+        assert str(q) == "s%20s=s%20s" 
+
         # Params is an omdict (ordered multivalue dictionary).
         q.params.clear()
         q.params.add('1', '1').set('2', '4').add('1', '11').addlist(
@@ -1285,6 +1289,13 @@ class TestFurl(unittest.TestCase):
 
         f.host = 'ohay.com'
         assert str(f) == 'sup://ohay.com/hay%20supppp?space=1+2#sup'
+
+    def test_use_quote_plus_as_false(self):
+        f = furl.furl('http://www.pumps.com/', use_quote_plus=False)
+
+        f.args['space'] = '1 2'
+
+        assert str(f) == 'http://www.pumps.com/?space=1%202'
 
     def test_odd_urls(self):
         # Empty.


### PR DESCRIPTION
Hi @gruns, I've been using your awesome library to handle assembling URLs on a few projects.  I've run into an issue where I need to encode URL parameters with `%20` instead of `+` signs, so it would be awesome if that were configurable in `furl`.  Both of these styles are valid: http://stackoverflow.com/questions/2678551/when-to-encode-space-to-plus-or-20

### What I did here

I added an extra parameter to `furl` called `use_quote_plus`, and added an extra property called `quote_method` to `Query`.  Let me know if you have better ideas for adding encoding options to `furl`.  Included unit tests that demonstrate usage.

Thanks a lot for taking a look at this, and for building this awesome library!