### PR TITLE
fix get scheme error

### DIFF
--- a/furl/furl.py
+++ b/furl/furl.py
@@ -188,6 +188,8 @@ def _get_scheme(url):
     beforeColon = url[:max(0, url.find(':'))]
     if beforeColon in COLON_SEPARATED_SCHEMES:
         return beforeColon
+    if '?' in beforeColon:
+        return None
     return url[:max(0, url.find('://'))] or None
 
 


### PR DESCRIPTION
## As Below
```
In [1]: from furl import urlsplit

In [2]: urlsplit('http://x.com/api/test?url=http://a.com')
Out[2]: SplitResult(scheme='http', netloc='x.com', path='/api/test', query='url=http://a.com', fragment='')

In [3]: urlsplit('/api/test?url=http://a.com')
Out[3]: SplitResult(scheme='/api/test?url=http', netloc='a.com', path='', query='', fragment='')

In [4]: from furl import furl

In [5]: furl('http://x.com/api/test?url=http://a.com').query
Out[5]: Query('url=http://a.com')

In [6]: furl('/api/test?url=http://a.com').query
Out[6]: Query('')
```

## About Scheme
I not find any description about scheme's format, just a list of registered schemes.
* http://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml

So I just add one line code to check whether ``?`` in ``beforeColon`` to solve above problem.

## Preferred Solution
What's your opinion?