### PR TITLE
Update furl.py to fix issue 92

### DIFF
--- a/furl/furl.py
+++ b/furl/furl.py
@@ -161,7 +161,7 @@ def static_vars(**kwargs):
 #   scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
 #
 PERCENT_REGEX = r'\%[a-fA-F\d][a-fA-F\d]'
-INVALID_DOMAIN_CHARS = '!@#$%^&\'\"*()+=:;/'
+INVALID_DOMAIN_CHARS = '!@#$%^&\'\"*()+=;/'
 
 
 @static_vars(regex=re.compile(


### PR DESCRIPTION
This fixes Issue #92 by removing ':' from the INVALID_DOMAIN_CHARS variable, allowing people to forward traffic to specific ports.