### PR TITLE
Fix original Path instance modification from __truediv__

### DIFF
--- a/furl/furl.py
+++ b/furl/furl.py
@@ -13,6 +13,7 @@
 import re
 import abc
 import warnings
+from copy import deepcopy
 from posixpath import normpath
 
 import six
@@ -629,10 +630,7 @@ class Path(object):
         return not self.isdir
 
     def __truediv__(self, path):
-        copy = self.__class__(
-            path=self.segments,
-            force_absolute=self._force_absolute,
-            strict=self.strict)
+        copy = deepcopy(self)
         return copy.add(path)
 
     def __eq__(self, other):

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -548,6 +548,12 @@ class TestPath(unittest.TestCase):
         p4 = furl.Path('f')
         assert p3 / p4 == furl.Path('e/f')
 
+        # Joining paths with __truediv__ should not modify the original, even if isabsolute is True
+        p5 = furl.Path(['a', 'b'], force_absolute=lambda _: True)
+        p6 = p5 / 'c'
+        assert str(p5) == '/a/b'
+        assert str(p6) == '/a/b/c'
+
     def test_asdict(self):
         segments = ['wiki', 'ロリポップ']
         path_encoded = 'wiki/%E3%83%AD%E3%83%AA%E3%83%9D%E3%83%83%E3%83%97'


### PR DESCRIPTION
Path class's __truediv__ should make a true copy, and not
modify the original instance of Path. Creating a new instance
with `path=self.segments` sets the new instance's path as a
pointer to the old instance's segments.

Also, add test assertion that the original instance is not
modified with __truediv__ when isabsolute is True.

Resolves: #127 