### PR TITLE
Add Python 3.8 and 3.9 to Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ matrix:
 
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
-    - python: 3.5
-      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
     - python: pypy
       env: TOXENV=pypy
     - python: pypy3

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -621,17 +621,17 @@ class TestQuery(unittest.TestCase):
             'space=a+a&amp=a%26a', 'a a=a a&no encoding=sup', 'a+a=a+a',
             'a%20=a+a', 'a%20a=a%20a', 'a+a=a%20a', 'space=a a&amp=a^a',
             'a=a&s=s#s', '+=+', "/?:@-._~!$&'()*+,=/?:@-._~!$'()*+,=",
-            'a=a&c=c%5Ec', '<=>&^="', '%3C=%3E&%5E=%22', '%=%;`=`',
+            'a=a&c=c%5Ec', '<=>&^="', '%3C=%3E&%5E=%22', '%=%&`=`',
             '%25=%25&%60=%60',
             # Only keys, no values.
             'asdfasdf', '/asdf/asdf/sdf', '*******', '!@#(*&@!#(*@!#', 'a&b',
-            'a;b',
+            'a&b',
             # Repeated parameters.
             'a=a&a=a', 'space=a+a&space=b+b',
             # Empty keys and/or values.
             '=', 'a=', 'a=a&a=', '=a&=b',
-            # Semicolon delimiter, like 'a=a;b=b'.
-            'a=a;a=a', 'space=a+a;space=b+b',
+            # Semicolon delimiter is not allowed per default after bpo#42967
+            'a=a&a=a', 'space=a+a&space=b+b',
         ]))
         self.items = (self.itemlists + self.itemdicts + self.itemomdicts +
                       self.itemstrs)

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -14,6 +14,7 @@ from __future__ import division
 
 import warnings
 from abc import ABCMeta, abstractmethod
+import sys
 
 import six
 from six.moves import zip
@@ -2055,9 +2056,13 @@ class TestFurl(unittest.TestCase):
         assert f.url == 'http://pepp.ru/a/b/c#uwantpump?'
 
         # In edge cases (e.g. URLs without an authority/netloc), behave
-        # identically to urllib.parse.urljoin().
+        # identically to urllib.parse.urljoin(), which changed behavior
+        # in Python 3.9
         f = furl.furl('wss://slrp.com/').join('foo:1')
-        assert f.url == 'wss://slrp.com/foo:1'
+        if sys.version_info[:2] < (3, 9):
+            assert f.url == 'wss://slrp.com/foo:1'
+        else:
+            assert f.url == 'foo:1'
         f = furl.furl('wss://slrp.com/').join('foo:1:rip')
         assert f.url == 'foo:1:rip'
         f = furl.furl('scheme:path').join('foo:blah')


### PR DESCRIPTION
Leave out EOL 3.4 and 3.5 to save resources.