### PR TITLE
Use ipaddress to detect valid and invalid IPs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(
     install_requires=[
         'six>=1.8.0',
         'orderedmultidict>=1.0.1',
+        'ipaddress>=1.0.23; python_version < "3.3"',
     ],
     cmdclass={
         'test': RunTests,

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -1655,10 +1655,10 @@ class TestFurl(unittest.TestCase):
         # addresses.
         f = furl.furl('http://1.2.3.4.5.6/')
 
-        # Invalid, but well-formed, IPv6 addresses shouldn't raise an
-        # exception because urlparse.urlsplit() doesn't raise an
-        # exception on invalid IPv6 addresses.
-        furl.furl('http://[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]/')
+        # Invalid, but well-formed, IPv6 addresses should raise an
+        # exception.
+        with self.assertRaises(ValueError):
+            furl.furl('http://[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]/')
 
         # Malformed IPv6 should raise an exception because urlparse.urlsplit()
         # raises an exception on malformed IPv6 addresses.
@@ -1684,11 +1684,16 @@ class TestFurl(unittest.TestCase):
         assert f.host == '1.2.3.4.5.6'
         assert f.port == 999
 
-        netloc = '[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]:888'
+        netloc = '[1:2:3:4:5:6:7:8]:888'
         f.netloc = netloc
         assert f.netloc == netloc
-        assert f.host == '[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]'
+        assert f.host == '[1:2:3:4:5:6:7:8]'
         assert f.port == 888
+
+        # Well-formed but invalid IPv6 should raise an exception
+        netloc = '[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]:888'
+        with self.assertRaises(ValueError):
+            f.netloc = netloc
 
         # Malformed IPv6 should raise an exception because
         # urlparse.urlsplit() raises an exception
@@ -1702,10 +1707,6 @@ class TestFurl(unittest.TestCase):
             f.netloc = '[0:0:0:0:0:0:0:1]:alksdflasdfasdf'
         with self.assertRaises(ValueError):
             f.netloc = 'pump2pump.org:777777777777'
-
-        # No side effects.
-        assert f.host == '[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]'
-        assert f.port == 888
 
         # Empty netloc.
         f = furl.furl('//')


### PR DESCRIPTION
Fixes #164 

This leads to a breaking change: well-formed but invalid IPv6 such as `[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]` now raise a `ValueError`. However one can argue that this is not exactly a behavior change but more a bugfix.

If you think the breaking change is too harsh, I can do another PR that would raise a deprecation warning when a well-formed invalid IPv6 is encountered, to be merged and released before this PR is merged and released.

What do you think?