### PR TITLE
Tolerate and correct IPv6 without brackets

### DIFF
--- a/furl/furl.py
+++ b/furl/furl.py
@@ -1478,6 +1478,15 @@ class furl(URLPathCompositionInterface, QueryCompositionInterface,
                 "have adjacent periods.")
             raise ValueError(errmsg % (host, INVALID_HOST_CHARS))
 
+        if (
+            is_valid_ipv6(host)
+            and callable_attr(host, 'startswith')
+            and callable_attr(host, 'endswith')
+            and not host.startswith("[")
+            and not host.endswith("]")
+        ):
+            host = "[" + host + "]"
+
         if callable_attr(host, 'lower'):
             host = host.lower()
         if callable_attr(host, 'startswith') and host.startswith('xn--'):

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(
     install_requires=[
         'six>=1.8.0',
         'orderedmultidict>=1.0.1',
+        'ipaddress>=1.0.23; python_version < "3.3"',
     ],
     cmdclass={
         'test': RunTests,

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -1655,10 +1655,10 @@ class TestFurl(unittest.TestCase):
         # addresses.
         f = furl.furl('http://1.2.3.4.5.6/')
 
-        # Invalid, but well-formed, IPv6 addresses shouldn't raise an
-        # exception because urlparse.urlsplit() doesn't raise an
-        # exception on invalid IPv6 addresses.
-        furl.furl('http://[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]/')
+        # Invalid, but well-formed, IPv6 addresses should raise an
+        # exception.
+        with self.assertRaises(ValueError):
+            furl.furl('http://[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]/')
 
         # Malformed IPv6 should raise an exception because urlparse.urlsplit()
         # raises an exception on malformed IPv6 addresses.
@@ -1684,11 +1684,16 @@ class TestFurl(unittest.TestCase):
         assert f.host == '1.2.3.4.5.6'
         assert f.port == 999
 
-        netloc = '[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]:888'
+        netloc = '[1:2:3:4:5:6:7:8]:888'
         f.netloc = netloc
         assert f.netloc == netloc
-        assert f.host == '[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]'
+        assert f.host == '[1:2:3:4:5:6:7:8]'
         assert f.port == 888
+
+        # Well-formed but invalid IPv6 should raise an exception
+        netloc = '[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]:888'
+        with self.assertRaises(ValueError):
+            f.netloc = netloc
 
         # Malformed IPv6 should raise an exception because
         # urlparse.urlsplit() raises an exception
@@ -1702,10 +1707,6 @@ class TestFurl(unittest.TestCase):
             f.netloc = '[0:0:0:0:0:0:0:1]:alksdflasdfasdf'
         with self.assertRaises(ValueError):
             f.netloc = 'pump2pump.org:777777777777'
-
-        # No side effects.
-        assert f.host == '[0:0:0:0:0:0:0:1:1:1:1:1:1:1:1:9999999999999]'
-        assert f.port == 888
 
         # Empty netloc.
         f = furl.furl('//')

--- a/tests/test_furl.py
+++ b/tests/test_furl.py
@@ -1655,6 +1655,15 @@ class TestFurl(unittest.TestCase):
         # addresses.
         f = furl.furl('http://1.2.3.4.5.6/')
 
+        # IPv6 without brackets should be corrected
+        f.set(host="::1")
+        assert f.host == "[::1]"
+        assert f.url == "http://[::1]/"
+
+        f.set(host="[::]")
+        assert f.host == "[::]"
+        assert f.url == "http://[::]/"
+
         # Invalid, but well-formed, IPv6 addresses should raise an
         # exception.
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This PR is based on #165 and fixes #124

Depending on the contexts, people does not always agree on brackets usage with IPv6. For instance, the [ipaddress core module](https://docs.python.org/3/library/ipaddress.html) handles IPv6 without brackets [as do some other low-level python modules](https://github.com/python/cpython/issues/85341). Another example: DNS AAAA records usually handles IPv6 without brackets.
However in a URL context, with a port number being optionally associated with an IP, the brackets become mandatory to distinguish the columns inside the IP from the column that separate the port number from the IP.

[As suggested in #124](https://github.com/gruns/furl/issues/124#issuecomment-640089076), I think this would be nice if a convenience utility like furl would tolerate and correct any usage. This would allow users to not need to check and correct manually the IPv6 they get from other libraries that may generate IPv6 without brackets because this is relevant in their development context. For instance a DNS SRV record being read with aiodns.

This is what this PR allows. There is not much code here, everything lies here:

```python
    def host(self, host):
        ...
        if (
            is_valid_ipv6(host)
            and callable_attr(host, 'startswith')
            and callable_attr(host, 'endswith')
            and not host.startswith("[")
            and not host.endswith("]")
        ):
            host = "[" + host + "]"
        ...
```

This allows this usage:

```python
        f.set(host="::1")
        assert f.host == "[::1]"
        assert f.url == "http://[::1]/"

        f.set(host="[::]")
        assert f.host == "[::]"
        assert f.url == "http://[::]/"
```