### PR TITLE
Make URL parser reject non-ASCII port strings

### DIFF
--- a/furl/furl.py
+++ b/furl/furl.py
@@ -130,7 +130,7 @@ def idna_decode(o):
 
 def is_valid_port(port):
     port = str(port)
-    if not port.isdigit() or not 0 < int(port) <= 65535:
+    if not port.isdigit() or not port.isascii() or not 0 < int(port) <= 65535:
         return False
     return True
 


### PR DESCRIPTION
Currently, the URL parser accepts non-ASCII digits such as `'౧'` in port numbers.
This is in violation of both the WHATWG URL standard and the RFCs.
This patch enforces that port numbers be composed only of ASCII digits..